### PR TITLE
repo.pp fix for puppetlabs/apt versions >= 2.0.0

### DIFF
--- a/manifests/profile/common/repo.pp
+++ b/manifests/profile/common/repo.pp
@@ -7,8 +7,8 @@ class quobyte::profile::common::repo(
   include apt
 
   apt::key { 'quobyte.key':
-    key        => $repo_key,
-    key_source => $repo_key_source
+    id        => $repo_key,
+    source => $repo_key_source
   }
 
   apt::source { 'quobyte':
@@ -16,7 +16,6 @@ class quobyte::profile::common::repo(
     release     => '',
     repos       => './',
     key         => $repo_key,
-    include_src => false,
   }
 
 }


### PR DESCRIPTION
fixed repo.pp according to changes in https://forge.puppetlabs.com/puppetlabs/apt/changelog
